### PR TITLE
Add DHCP stop on IPPool not ready

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -41,6 +41,7 @@ func NewAgent(options *config.AgentOptions) *Agent {
 			options.IPPoolRef,
 			dhcpAllocator,
 			poolCache,
+			options.Nic,
 		),
 		poolCache: poolCache,
 	}

--- a/pkg/agent/ippool/controller.go
+++ b/pkg/agent/ippool/controller.go
@@ -23,6 +23,7 @@ type Controller struct {
 	poolRef       types.NamespacedName
 	dhcpAllocator *dhcp.DHCPAllocator
 	poolCache     map[string]string
+	nic           string
 }
 
 func NewController(
@@ -32,6 +33,7 @@ func NewController(
 	poolRef types.NamespacedName,
 	dhcpAllocator *dhcp.DHCPAllocator,
 	poolCache map[string]string,
+	nic string,
 ) *Controller {
 	return &Controller{
 		stopCh:        make(chan struct{}),
@@ -41,6 +43,7 @@ func NewController(
 		poolRef:       poolRef,
 		dhcpAllocator: dhcpAllocator,
 		poolCache:     poolCache,
+		nic:           nic,
 	}
 }
 

--- a/pkg/agent/ippool/event.go
+++ b/pkg/agent/ippool/event.go
@@ -33,6 +33,7 @@ type EventHandler struct {
 	poolRef       types.NamespacedName
 	dhcpAllocator *dhcp.DHCPAllocator
 	poolCache     map[string]string
+	nic           string
 }
 
 type Event struct {
@@ -49,6 +50,7 @@ func NewEventHandler(
 	poolRef types.NamespacedName,
 	dhcpAllocator *dhcp.DHCPAllocator,
 	poolCache map[string]string,
+	nic string,
 ) *EventHandler {
 	return &EventHandler{
 		kubeConfig:     kubeConfig,
@@ -57,6 +59,7 @@ func NewEventHandler(
 		poolRef:        poolRef,
 		dhcpAllocator:  dhcpAllocator,
 		poolCache:      poolCache,
+		nic:            nic,
 	}
 }
 
@@ -112,7 +115,7 @@ func (e *EventHandler) EventListener(ctx context.Context) {
 		},
 	}, cache.Indexers{})
 
-	controller := NewController(queue, indexer, informer, e.poolRef, e.dhcpAllocator, e.poolCache)
+	controller := NewController(queue, indexer, informer, e.poolRef, e.dhcpAllocator, e.poolCache, e.nic)
 
 	go controller.Run(1)
 

--- a/pkg/agent/ippool/ippool.go
+++ b/pkg/agent/ippool/ippool.go
@@ -10,6 +10,9 @@ import (
 func (c *Controller) Update(ipPool *networkv1.IPPool) error {
 	if !networkv1.CacheReady.IsTrue(ipPool) {
 		logrus.Warningf("ippool %s/%s is not ready", ipPool.Namespace, ipPool.Name)
+		if err := c.dhcpAllocator.Stop(c.nic); err != nil {
+			logrus.Errorf("(controller.Update) failed to stop DHCP service: %v", err)
+		}
 		return nil
 	}
 	if ipPool.Status.IPv4 == nil {

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -328,6 +328,12 @@ func (a *DHCPAllocator) stop(nic string) (err error) {
 	return a.servers[nic].Close()
 }
 
+// Stop stops the running DHCP server on the given network interface.
+// It is safe to call Stop multiple times for the same interface.
+func (a *DHCPAllocator) Stop(nic string) error {
+	return a.stop(nic)
+}
+
 func (a *DHCPAllocator) ListAll(name string) (map[string]string, error) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()


### PR DESCRIPTION
## Summary
- add exported Stop() to DHCP allocator
- stop DHCP service if IPPool becomes not ready
- carry nic information through agent controller creation

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68501980d878832290750c23d225d26e