### PR TITLE
Fix stuck pods cleanup

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/signals"
@@ -16,6 +17,7 @@ import (
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
 	"github.com/harvester/vm-dhcp-controller/pkg/controller"
 	"github.com/harvester/vm-dhcp-controller/pkg/server"
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 )
 
 var (
@@ -45,6 +47,8 @@ func run(options *config.ControllerOptions) error {
 	if err != nil {
 		logrus.Fatalf("Error building controllers: %s", err.Error())
 	}
+
+	go util.CleanupTerminatingPods(ctx, client, options.AgentNamespace, "controller", time.Minute)
 
 	callback := func(ctx context.Context) {
 		if err := management.Register(ctx, cfg, controller.RegisterFuncList); err != nil {

--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"time"
 
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 	"github.com/harvester/webhook/pkg/config"
 	"github.com/harvester/webhook/pkg/server"
 	"github.com/rancher/wrangler/pkg/start"
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	ctlcore "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/core"
@@ -69,6 +72,13 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 	if err != nil {
 		return err
 	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	go util.CleanupTerminatingPods(ctx, client, options.Namespace, "webhook", time.Minute)
 
 	webhookServer := server.NewWebhookServer(ctx, cfg, name, options)
 

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CleanupTerminatingPods forcibly deletes pods with the specified component label
+// that have been stuck in the Terminating state for longer than the given
+// threshold.
+func CleanupTerminatingPods(ctx context.Context, client kubernetes.Interface, namespace, component string, threshold time.Duration) {
+	if client == nil || namespace == "" || component == "" {
+		return
+	}
+
+	selector := labels.Set{"app.kubernetes.io/component": component}.AsSelector().String()
+	ticker := time.NewTicker(threshold / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+			if err != nil {
+				logrus.Errorf("(CleanupTerminatingPods) list pods error: %v", err)
+				continue
+			}
+
+			for i := range pods.Items {
+				pod := &pods.Items[i]
+				if pod.DeletionTimestamp == nil {
+					continue
+				}
+				if time.Since(pod.DeletionTimestamp.Time) < threshold {
+					continue
+				}
+
+				logrus.Infof("(CleanupTerminatingPods) force deleting stuck pod %s/%s", pod.Namespace, pod.Name)
+
+				if len(pod.Finalizers) > 0 {
+					patchBody, _ := json.Marshal(map[string]any{
+						"metadata": map[string]any{"finalizers": nil},
+					})
+					if _, err := client.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBody, metav1.PatchOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						logrus.Errorf("(CleanupTerminatingPods) patch pod %s/%s finalizers error: %v", pod.Namespace, pod.Name, err)
+					}
+				}
+
+				grace := int64(0)
+				policy := metav1.DeletePropagationBackground
+				if err := client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace, PropagationPolicy: &policy}); err != nil && !apierrors.IsNotFound(err) {
+					logrus.Errorf("(CleanupTerminatingPods) delete pod %s/%s error: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add util to force delete pods stuck in Terminating
- clean up old controller and webhook pods on startup
- remove finalizers when forcibly deleting pods

## Testing
- `gofmt -w pkg/util/pod.go cmd/controller/run.go cmd/webhook/run.go`
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*
- `go mod tidy` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_68518505887483228f53e256c5913c4a