### PR TITLE
Fix stuck pod cleanup

### DIFF
--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -8,6 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -44,6 +45,14 @@ func CleanupTerminatingPods(ctx context.Context, client kubernetes.Interface, na
 				}
 
 				logrus.Infof("(CleanupTerminatingPods) force deleting stuck pod %s/%s", pod.Namespace, pod.Name)
+
+				if len(pod.Finalizers) > 0 {
+					patch := []byte(`{"metadata":{"finalizers":null}}`)
+					if _, err := client.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						logrus.Errorf("(CleanupTerminatingPods) patch pod %s/%s error: %v", pod.Namespace, pod.Name, err)
+					}
+				}
+
 				grace := int64(0)
 				if err := client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
 					logrus.Errorf("(CleanupTerminatingPods) delete pod %s/%s error: %v", pod.Namespace, pod.Name, err)


### PR DESCRIPTION
## Summary
- patch stuck pods to remove finalizers before forced delete

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852e27905688322b8654920909f7fff