### PR TITLE
Add agent deployment support

### DIFF
--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -22,6 +22,7 @@ var (
 	dryRun             bool
 	nic                string
 	enableCacheDumpAPI bool
+	noLeaderElection   bool
 	kubeConfigPath     string
 	kubeContext        string
 	ippoolRef          string
@@ -74,6 +75,7 @@ func init() {
 	rootCmd.Flags().StringVar(&kubeContext, "kubecontext", os.Getenv("KUBECONTEXT"), "Context name")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run vm-dhcp-agent without starting the DHCP server")
 	rootCmd.Flags().BoolVar(&enableCacheDumpAPI, "enable-cache-dump-api", false, "Enable cache dump APIs")
+	rootCmd.Flags().BoolVar(&noLeaderElection, "no-leader-election", false, "Run vm-dhcp-agent with leader election disabled")
 	rootCmd.Flags().StringVar(&ippoolRef, "ippool-ref", os.Getenv("IPPOOL_REF"), "The IPPool object the agent should sync with")
 	rootCmd.Flags().StringVar(&nic, "nic", agent.DefaultNetworkInterface, "The network interface the embedded DHCP server listens on")
 }

--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
+	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/agent"
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
@@ -18,37 +23,71 @@ func run(options *config.AgentOptions) error {
 
 	ctx := signals.SetupSignalContext()
 
-	agent := agent.NewAgent(options)
-
-	httpServerOptions := config.HTTPServerOptions{
-		DebugMode:     enableCacheDumpAPI,
-		DHCPAllocator: agent.DHCPAllocator,
-	}
-	s := server.NewHTTPServer(&httpServerOptions)
-	s.RegisterAgentHandlers()
-
-	eg, egctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		return s.Run()
-	})
-
-	eg.Go(func() error {
-		return agent.Run(egctx)
-	})
-
-	errCh := server.Cleanup(egctx, s)
-
-	if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	cfg, err := buildRestConfig(options.KubeConfigPath, options.KubeContext)
+	if err != nil {
 		return err
 	}
 
-	// Return cleanup error message if any
-	if err := <-errCh; err != nil {
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
 		return err
+	}
+
+	callback := func(ctx context.Context) {
+		agent := agent.NewAgent(options)
+
+		httpServerOptions := config.HTTPServerOptions{
+			DebugMode:     enableCacheDumpAPI,
+			DHCPAllocator: agent.DHCPAllocator,
+		}
+		s := server.NewHTTPServer(&httpServerOptions)
+		s.RegisterAgentHandlers()
+
+		eg, egctx := errgroup.WithContext(ctx)
+
+		eg.Go(func() error {
+			return s.Run()
+		})
+
+		eg.Go(func() error {
+			return agent.Run(egctx)
+		})
+
+		errCh := server.Cleanup(egctx, s)
+
+		if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logrus.Errorf("agent runtime error: %v", err)
+		}
+
+		if err := <-errCh; err != nil {
+			logrus.Errorf("cleanup error: %v", err)
+		}
+	}
+
+	if noLeaderElection {
+		callback(ctx)
+		<-ctx.Done()
+	} else {
+		leader.RunOrDie(ctx, "kube-system", "vm-dhcp-agent-"+options.IPPoolRef.Name, client, callback)
 	}
 
 	logrus.Info("finished clean")
 
 	return nil
+}
+
+func buildRestConfig(kubeconfig, kubecontext string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		if cfg, err := rest.InClusterConfig(); err == nil {
+			return cfg, nil
+		}
+	}
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	overrides := &clientcmd.ConfigOverrides{}
+	if kubecontext != "" {
+		overrides.CurrentContext = kubecontext
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 }

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -8,11 +8,13 @@ import (
 	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
@@ -33,8 +35,9 @@ const (
 	multusNetworksAnnotationKey         = "k8s.v1.cni.cncf.io/networks"
 	holdIPPoolAgentUpgradeAnnotationKey = "network.harvesterhci.io/hold-ippool-agent-upgrade"
 
-	vmDHCPControllerLabelKey = network.GroupName + "/vm-dhcp-controller"
-	clusterNetworkLabelKey   = network.GroupName + "/clusternetwork"
+	vmDHCPControllerLabelKey       = network.GroupName + "/vm-dhcp-controller"
+	clusterNetworkLabelKey         = network.GroupName + "/clusternetwork"
+	agentReplicas            int32 = 2
 
 	setIPAddrScript = `
 #!/usr/bin/env sh
@@ -72,6 +75,7 @@ type Handler struct {
 	ippoolCache      ctlnetworkv1.IPPoolCache
 	podClient        ctlcorev1.PodClient
 	podCache         ctlcorev1.PodCache
+	deploymentClient kubernetes.Interface
 	nadClient        ctlcniv1.NetworkAttachmentDefinitionClient
 	nadCache         ctlcniv1.NetworkAttachmentDefinitionCache
 }
@@ -97,6 +101,7 @@ func Register(ctx context.Context, management *config.Management) error {
 		ippoolCache:      ippools.Cache(),
 		podClient:        pods,
 		podCache:         pods.Cache(),
+		deploymentClient: management.ClientSet,
 		nadClient:        nads,
 		nadCache:         nads.Cache(),
 	}
@@ -297,30 +302,23 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	if ipPool.Status.AgentPodRef != nil {
 		status.AgentPodRef.Image = h.getAgentImage(ipPool)
-		pod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+		dep, err := h.deploymentClient.AppsV1().Deployments(h.agentNamespace).Get(context.TODO(), ipPool.Status.AgentPodRef.Name, metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return status, err
 			}
 
-			logrus.Warningf("(ippool.DeployAgent) agent pod %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
+			logrus.Warningf("(ippool.DeployAgent) agent deployment %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
 		} else {
-			if pod.DeletionTimestamp != nil {
-				logrus.Warningf("(ippool.DeployAgent) deleting stuck agent pod %s", pod.Name)
-				if err := h.forceDeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
-					return status, err
-				}
-			} else {
-				if pod.GetUID() != ipPool.Status.AgentPodRef.UID {
-					return status, fmt.Errorf("agent pod %s uid mismatch", ipPool.Status.AgentPodRef.Name)
-				}
-
-				return status, nil
+			if dep.GetUID() != ipPool.Status.AgentPodRef.UID {
+				return status, fmt.Errorf("agent deployment %s uid mismatch", dep.Name)
 			}
+
+			return status, nil
 		}
 	}
 
-	agent, err := prepareAgentPod(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
+	agent, err := prepareAgentDeployment(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
 	if err != nil {
 		return status, err
 	}
@@ -331,7 +329,7 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	status.AgentPodRef.Image = h.agentImage.String()
 
-	agentPod, err := h.podClient.Create(agent)
+	agentDep, err := h.deploymentClient.AppsV1().Deployments(agent.Namespace).Create(context.TODO(), agent, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return status, nil
@@ -341,9 +339,9 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	logrus.Infof("(ippool.DeployAgent) agent for ippool %s/%s has been deployed", ipPool.Namespace, ipPool.Name)
 
-	status.AgentPodRef.Namespace = agentPod.Namespace
-	status.AgentPodRef.Name = agentPod.Name
-	status.AgentPodRef.UID = agentPod.GetUID()
+	status.AgentPodRef.Namespace = agentDep.Namespace
+	status.AgentPodRef.Name = agentDep.Name
+	status.AgentPodRef.UID = agentDep.GetUID()
 
 	return status, nil
 }
@@ -439,28 +437,35 @@ func (h *Handler) MonitorAgent(ipPool *networkv1.IPPool, status networkv1.IPPool
 		return status, fmt.Errorf("agent for ippool %s/%s is not deployed", ipPool.Namespace, ipPool.Name)
 	}
 
-	agentPod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+	sets := labels.Set{
+		vmDHCPControllerLabelKey:     "agent",
+		util.IPPoolNamespaceLabelKey: ipPool.Namespace,
+		util.IPPoolNameLabelKey:      ipPool.Name,
+	}
+
+	pods, err := h.podCache.List(h.agentNamespace, sets.AsSelector())
 	if err != nil {
 		return status, err
 	}
 
-	if agentPod.GetUID() != ipPool.Status.AgentPodRef.UID || agentPod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
-		if agentPod.DeletionTimestamp != nil {
-			return status, fmt.Errorf("agent pod %s marked for deletion", agentPod.Name)
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
 		}
 
-		if err := h.forceDeletePod(agentPod.Namespace, agentPod.Name); err != nil {
-			return status, err
+		if pod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
+			continue
 		}
 
-		return status, fmt.Errorf("agent pod %s obsolete and purged", agentPod.Name)
+		if isPodReady(pod) {
+			status.AgentPodRef.Namespace = pod.Namespace
+			status.AgentPodRef.Name = pod.Name
+			status.AgentPodRef.UID = pod.GetUID()
+			return status, nil
+		}
 	}
 
-	if !isPodReady(agentPod) {
-		return status, fmt.Errorf("agent pod %s not ready", agentPod.Name)
-	}
-
-	return status, nil
+	return status, fmt.Errorf("no ready agent pod for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 }
 
 func isPodReady(pod *corev1.Pod) bool {


### PR DESCRIPTION
## Summary
- deploy agent as Kubernetes Deployment with replica set
- monitor deployment pods for readiness

## Testing
- `./scripts/test` *(fails: modules download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68625dddea6c8322b9f2ce093d1c86ac